### PR TITLE
Fix IRQ premature release issue

### DIFF
--- a/PicFirmware.c
+++ b/PicFirmware.c
@@ -193,9 +193,12 @@ void main(void)
 	
    at_initprocessor();
 
+   // wait for first access before de-asserting irq
+   //
+   PIR1bits.PSPIF = 0;
+   while (PIR1bits.PSPIF == 0){}
    RELEASEIRQ();
-
-    _asm nop _endasm;
+   at_process();
 
 doneprocessing:
    ACTIVITYSTROBE(1);

--- a/atmmc2.h
+++ b/atmmc2.h
@@ -9,7 +9,7 @@
 #endif
 
 #define VSN_MAJ 2
-#define VSN_MIN 12
+#define VSN_MIN 13
 
 #define SECBUFFSIZE 512
 #define GLOBUFFSIZE 256


### PR DESCRIPTION
Fix race condition where the interface firmware de-asserts the IRQ before the Atom has had a chance to acknowledge it.

By waiting until the Atom communicates with the interface we guarantee it's ready.
